### PR TITLE
styling of input in safari

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -164,6 +164,8 @@ a {
   font-size: 30px;
   color: #3a416f;
   outline: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 @media (max-width: 700px) {
   .hero-input .ais-input {


### PR DESCRIPTION
before|after
---|---
<img width="763" alt="screen shot 2018-06-05 at 15 07 15" src="https://user-images.githubusercontent.com/6270048/40977751-2ed610e8-68d2-11e8-9cce-398d89fe2162.png"> | <img width="861" alt="screen shot 2018-06-05 at 15 07 11" src="https://user-images.githubusercontent.com/6270048/40977750-2ebb4a38-68d2-11e8-9fc7-7799a99a0045.png">